### PR TITLE
Enable SSL Mail Auth toggle; corrected OAI_FILE value

### DIFF
--- a/gui/src/main/java/harvesterUI/client/panels/administration/AdminForm.java
+++ b/gui/src/main/java/harvesterUI/client/panels/administration/AdminForm.java
@@ -52,7 +52,8 @@ public class AdminForm extends VerticalPanel {
       repoxDefaultEmailSenderField, repoxDefualtEmailPassField, ldapHostField, ldapPassField,
       ldapRootDN, ldapBasePath, httpRequestField, sampleRecordsField, backendUrl;
 
-  private CheckBox useCountriesTxtFile, sendEmailAfterIngest, useOAINamespace;
+  private CheckBox useCountriesTxtFile, sendEmailAfterIngest, useMailSSLAuthentication,
+      useOAINamespace;
 
   public AdminForm() {
     service = (RepoxServiceAsync) Registry.get(HarvesterUI.REPOX_SERVICE);
@@ -261,12 +262,12 @@ public class AdminForm extends VerticalPanel {
     checkBoxGroup.add(sendEmailAfterIngest);
     simple.add(checkBoxGroup, formData);
 
-    // checkBoxGroup = new CheckBoxGroup();
-    // useMailSSLAuthentication = new CheckBox();
-    // checkBoxGroup.setId("useMailSSLAuthentication");
-    // checkBoxGroup.setFieldLabel("Use SSL Mail Authentication?");
-    // checkBoxGroup.add(useMailSSLAuthentication);
-    // simple.add(checkBoxGroup, formData);
+    checkBoxGroup = new CheckBoxGroup();
+    useMailSSLAuthentication = new CheckBox();
+    checkBoxGroup.setId("useMailSSLAuthentication");
+    checkBoxGroup.setFieldLabel("Use SSL Mail Authentication?");
+    checkBoxGroup.add(useMailSSLAuthentication);
+    simple.add(checkBoxGroup, formData);
 
     checkBoxGroup = new CheckBoxGroup();
     useOAINamespace = new CheckBox();
@@ -300,7 +301,7 @@ public class AdminForm extends VerticalPanel {
                 adminInfo.set("ldapBasePath", ldapBasePath.getValue());
                 adminInfo.set("useCountriesTxt", useCountriesTxtFile.getValue());
                 adminInfo.set("sendEmailAfterIngest", sendEmailAfterIngest.getValue());
-                // adminInfo.set("useMailSSLAuthentication", useMailSSLAuthentication.getValue());
+                adminInfo.set("useMailSSLAuthentication", useMailSSLAuthentication.getValue());
                 adminInfo.set("useOAINamespace", useOAINamespace.getValue());
                 adminInfo.set("backendUrl", backendUrl.getValue());
                 adminInfo.set("oaiRepoName", repositoryNameField.getValue());
@@ -374,7 +375,7 @@ public class AdminForm extends VerticalPanel {
         ldapBasePath.setValue((String) dataModel.get("ldapBasePath"));
         useCountriesTxtFile.setValue((Boolean) dataModel.get("useCountriesTxt"));
         sendEmailAfterIngest.setValue((Boolean) dataModel.get("sendEmailAfterIngest"));
-        // useMailSSLAuthentication.setValue((Boolean) dataModel.get("useMailSSLAuthentication"));
+        useMailSSLAuthentication.setValue((Boolean) dataModel.get("useMailSSLAuthentication"));
         useOAINamespace.setValue((Boolean) dataModel.get("useOAINamespace"));
         backendUrl.setValue((String) dataModel.get("backendUrl"));
         repositoryNameField.setValue((String) dataModel.get("oaiRepoName"));

--- a/gui/src/main/java/harvesterUI/server/projects/DefaultProjectManager.java
+++ b/gui/src/main/java/harvesterUI/server/projects/DefaultProjectManager.java
@@ -198,7 +198,7 @@ public class DefaultProjectManager extends ProjectManager {
       adminInfo.set("sampleRecords", configuration.getSampleRecords());
       adminInfo.set("useCountriesTxt", configuration.getUseCountriesTxt());
       adminInfo.set("sendEmailAfterIngest", configuration.getSendEmailAfterIngest());
-      // adminInfo.set("useMailSSLAuthentication",configuration.isUseMailSSLAuthentication());
+      adminInfo.set("useMailSSLAuthentication",configuration.isUseMailSSLAuthentication());
       adminInfo.set("useOAINamespace", configuration.isUseOAINamespace());
 
       // optional fields
@@ -243,7 +243,7 @@ public class DefaultProjectManager extends ProjectManager {
           .setProperty("userCountriesTxtFile", String.valueOf(results.get("useCountriesTxt")));
       properties.setProperty("sendEmailAfterIngest",
           String.valueOf(results.get("sendEmailAfterIngest")));
-      // properties.setProperty("useMailSSLAuthentication",String.valueOf(results.get("useMailSSLAuthentication")));
+      properties.setProperty("useMailSSLAuthentication",String.valueOf(results.get("useMailSSLAuthentication")));
       properties.setProperty("useOAINamespace", String.valueOf(results.get("useOAINamespace")));
 
       // optional fields

--- a/manager/src/main/java/pt/utl/ist/configuration/RepoxConfiguration.java
+++ b/manager/src/main/java/pt/utl/ist/configuration/RepoxConfiguration.java
@@ -46,7 +46,7 @@ public abstract class RepoxConfiguration {
     private static final String PROPERTY_USE_COUNTRIES_TXT           = "userCountriesTxtFile";
     private static final String PROPERTY_SEND_EMAIL_AFTER_INGESTION  = "sendEmailAfterIngest";
 //    private static final String PROPERTY_SERVER_OAI_URL              = "currentServerOAIUrl";
-//    private static final String PROPERTY_USE_MAIL_AUTHENTICATION     = "useMailSSLAuthentication";
+    private static final String PROPERTY_USE_MAIL_AUTHENTICATION     = "useMailSSLAuthentication";
     private static final String PROPERTY_USE_OAI_NAMESPACE           = "useOAINamespace";
 
     private String              baseUrn;
@@ -76,7 +76,7 @@ public abstract class RepoxConfiguration {
     private Boolean             useCountriesTxt;
     private Boolean             sendEmailAfterIngest;
 //    private String              currentServerOAIUrl;
-//    private boolean             useMailSSLAuthentication;
+    private boolean             useMailSSLAuthentication;
     private boolean             useOAINamespace;
 
     /**
@@ -151,7 +151,7 @@ public abstract class RepoxConfiguration {
         this.sendEmailAfterIngest = Boolean.valueOf((String)configuration.getProperty(PROPERTY_SEND_EMAIL_AFTER_INGESTION) == null ? "true" : (String)configuration
                 .getProperty(PROPERTY_SEND_EMAIL_AFTER_INGESTION));
 
-//        this.useMailSSLAuthentication = Boolean.valueOf((String)configuration.getProperty(PROPERTY_USE_MAIL_AUTHENTICATION) == null ? "true" : (String)configuration.getProperty(PROPERTY_USE_MAIL_AUTHENTICATION));
+        this.useMailSSLAuthentication = Boolean.valueOf((String)configuration.getProperty(PROPERTY_USE_MAIL_AUTHENTICATION) == null ? "true" : (String)configuration.getProperty(PROPERTY_USE_MAIL_AUTHENTICATION));
         this.useOAINamespace = Boolean.valueOf((String)configuration.getProperty(PROPERTY_USE_OAI_NAMESPACE) == null ? "false" : (String)configuration.getProperty(PROPERTY_USE_OAI_NAMESPACE));
         
 //      this.currentServerOAIUrl = (String)configuration.getProperty(PROPERTY_SERVER_OAI_URL);
@@ -301,9 +301,9 @@ public abstract class RepoxConfiguration {
 //        return currentServerOAIUrl;
 //    }
 
-//    public boolean isUseMailSSLAuthentication() {
-//        return useMailSSLAuthentication;
-//    }
+    public boolean isUseMailSSLAuthentication() {
+        return useMailSSLAuthentication;
+    }
 
     public boolean isUseOAINamespace() {
         return useOAINamespace;

--- a/manager/src/main/java/pt/utl/ist/configuration/RepoxContextUtil.java
+++ b/manager/src/main/java/pt/utl/ist/configuration/RepoxContextUtil.java
@@ -14,7 +14,7 @@ public interface RepoxContextUtil {
     /** RepoxContextUtil TEST_CONFIG_FILE */
     String TEST_CONFIG_FILE = "Test-configuration.properties";
     /** RepoxContextUtil OAI_FILE */
-    String OAI_FILE      = "oai.properties";
+    String OAI_FILE      = "oaicat.properties";
 
     RepoxManager getRepoxManager();
 

--- a/manager/src/main/java/pt/utl/ist/util/DefaultEmailUtil.java
+++ b/manager/src/main/java/pt/utl/ist/util/DefaultEmailUtil.java
@@ -46,17 +46,20 @@ public class DefaultEmailUtil implements EmailUtil {
         }
 
         JavaMailSenderImpl mail = new JavaMailSenderImpl();
-        mail.setUsername(fromEmail);
-        mail.setPassword(adminMailPass);
         mail.setPort(Integer.valueOf(smtpPort));
         mail.setHost(smtpServer);
 
-        Properties mailConnectionProperties = (Properties)System.getProperties().clone();
-        mailConnectionProperties.put("mail.smtp.auth", "true");
-        mailConnectionProperties.put("mail.smtp.starttls.enable", "true");
-        mailConnectionProperties.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
-        mailConnectionProperties.put("mail.smtp.socketFactory.fallback", "false");
-        mail.setJavaMailProperties(mailConnectionProperties);
+        if (ConfigSingleton.getRepoxContextUtil().getRepoxManager().getConfiguration().isUseMailSSLAuthentication()) {
+            mail.setUsername(fromEmail);
+            mail.setPassword(adminMailPass);
+
+            Properties mailConnectionProperties = (Properties)System.getProperties().clone();
+            mailConnectionProperties.put("mail.smtp.auth", "true");
+            mailConnectionProperties.put("mail.smtp.starttls.enable", "true");
+            mailConnectionProperties.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
+            mailConnectionProperties.put("mail.smtp.socketFactory.fallback", "false");
+            mail.setJavaMailProperties(mailConnectionProperties);
+        }
 
         emailSender.setMailSender(mail);
         if (map.get("mailType").equals("ingest")) {

--- a/resources/src/main/resources/configuration.properties
+++ b/resources/src/main/resources/configuration.properties
@@ -65,4 +65,5 @@ database.password = repox
 
 userCountriesTxtFile = false
 sendEmailAfterIngest = false
+useMailSSLAuthentication = true
 useOAINamespace = false


### PR DESCRIPTION
Re-enabled SSL Mail Authentication configuration setting, and added code so that it's actually used when sending emails. The setting will now toggle use of SSL and user based authentication for sending SMTP email.  

Also fixed the value of the OAI_FILE variable.